### PR TITLE
Replace deprecated dash-functional dependency

### DIFF
--- a/source/wonderland.el
+++ b/source/wonderland.el
@@ -3,7 +3,7 @@
 ;; Copyright (c) 2013 Christina Whyte <kurisu.whyte@gmail.com>
 
 ;; Version: 0.1.1
-;; Package-Requires: ((dash "2.0.0") (dash-functional "1.0.0") (multi "2.0.0") (emacs "24"))
+;; Package-Requires: ((dash "2.18.0") (multi "2.0.0") (emacs "24"))
 ;; Keywords: configuration profile wonderland
 ;; Author: Christina Whyte <kurisu.whyte@gmail.com>
 ;; URL: http://github.com/kurisuwhyte/emacs-wonderland
@@ -42,7 +42,6 @@
 ;;; Code:
 (eval-when-compile (require 'cl))
 (require 'dash)
-(require 'dash-functional)
 (require 'multi)
 
 


### PR DESCRIPTION
Dash 2.18.0 now subsumes `dash-functional`.

See https://github.com/magnars/dash.el/blob/master/NEWS.md#from-217-to-218